### PR TITLE
fix wrongly quoted IdentityAgent "//./pipe/somefile"

### DIFF
--- a/config.go
+++ b/config.go
@@ -402,7 +402,7 @@ func (c *Config) Get(alias, key string) (string, error) {
 					panic("can't handle Match directives")
 				}
 				if lkey == lowerKey {
-					return t.Value, nil
+					return strings.Trim(t.Value, `"`), nil
 				}
 			case *Include:
 				val := t.Get(alias, key)

--- a/config.go
+++ b/config.go
@@ -402,7 +402,7 @@ func (c *Config) Get(alias, key string) (string, error) {
 					panic("can't handle Match directives")
 				}
 				if lkey == lowerKey {
-					return strings.Trim(t.Value, `"`), nil
+					return strings.Trim(t.Value, `"`), nil // look TestGetQuoted in config_test.go
 				}
 			case *Include:
 				val := t.Get(alias, key)

--- a/config_test.go
+++ b/config_test.go
@@ -554,3 +554,14 @@ func TestCommentValue(t *testing.T) {
 		}
 	}
 }
+
+func TestGetQuoted(t *testing.T) {
+	us := &UserSettings{
+		userConfigFinder: testConfigFinder("testdata/config1"),
+	}
+
+	val := us.Get("wap", "XAuthLocation")
+	if val != `/usr/bin/xauth` {
+		t.Errorf("expected to find `/usr/bin/xauth`, got `%s`", val)
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -561,7 +561,32 @@ func TestGetQuoted(t *testing.T) {
 	}
 
 	val := us.Get("wap", "XAuthLocation")
-	if val != `/usr/bin/xauth` {
-		t.Errorf("expected to find `/usr/bin/xauth`, got `%s`", val)
+	expectedValue := `/usr/bin/xauth`
+	if val != expectedValue {
+		t.Errorf("expected to find `%s`, got `%s`", expectedValue, val)
+	}
+}
+
+func TestGetQuotedSSV(t *testing.T) {
+	us := &UserSettings{
+		userConfigFinder: testConfigFinder("testdata/config1"),
+	}
+
+	val := us.Get("wap", "UserKnownHostsFile")
+	expectedValue := `~/.ssh/12 ~/.ssh/34 "~/.ssh/5 6"`
+	if val != expectedValue {
+		t.Errorf("expected to find `%s`, got `%s`", expectedValue, val)
+	}
+}
+
+func TestGetCommand(t *testing.T) {
+	us := &UserSettings{
+		userConfigFinder: testConfigFinder("testdata/config1"),
+	}
+
+	val := us.Get("wopr", "ProxyCommand")
+	expectedValue := `sh -c "ssh proxy1 -qW %h:22 || ssh proxy2 -qW %h:22"`
+	if val != expectedValue {
+		t.Errorf("expected to find `%s`, got `%s`", expectedValue, val)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/trzsz/ssh_config
 
 go 1.18
+
+require github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=

--- a/testdata/config1
+++ b/testdata/config1
@@ -37,3 +37,5 @@ Host *
   HostKeyAlgorithms ssh-ed25519,ssh-rsa
   AddressFamily inet
   #UpdateHostKeys ask
+  UserKnownHostsFile "~/.ssh/12" ~/.ssh/34 "~/.ssh/5 6"
+

--- a/testdata/config1
+++ b/testdata/config1
@@ -32,7 +32,7 @@ Host *
   #ControlPath /tmp/ssh-%u-%r@%h:%p
   #ControlPersist yes
   ForwardX11Timeout 52w
-  XAuthLocation /usr/bin/xauth
+  XAuthLocation "/usr/bin/xauth"
   SendEnv LANG LC_*
   HostKeyAlgorithms ssh-ed25519,ssh-rsa
   AddressFamily inet


### PR DESCRIPTION
`IdentityAgent //./pipe/somefile` works well but `IdentityAgent "//./pipe/somefile"` fail
Please take a look:
[Arguments may optionally be enclosed in double quotes (") in order to represent arguments containing spaces](https://man.openbsd.org/ssh_config.5)
In my case, `somefile` did not contain spaces, but you have to forgive other people's mistakes so that someone forgives ours.